### PR TITLE
NGSTACK-379: add keep_request_method option for redirects

### DIFF
--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -56,6 +56,7 @@ class ContentView extends AbstractParser
                                 $v['redirect'] = [
                                     'target' => $value,
                                     'permanent' => $permanent,
+                                    'keep_request_method' => true,
                                     'absolute' => false,
                                 ];
 
@@ -90,6 +91,9 @@ class ContentView extends AbstractParser
                                     ->end()
                                     ->booleanNode('permanent')
                                         ->defaultFalse()
+                                    ->end()
+                                    ->booleanNode('keep_request_method')
+                                        ->defaultTrue()
                                     ->end()
                                     ->booleanNode('absolute')
                                         ->defaultFalse()

--- a/bundle/EventListener/InternalContentViewRouteListener.php
+++ b/bundle/EventListener/InternalContentViewRouteListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\Routing\RouterInterface;
 use function class_exists;
 use function in_array;
 
-class InternalContentViewRouteListener implements EventSubscriberInterface
+final class InternalContentViewRouteListener implements EventSubscriberInterface
 {
     private ConfigResolverInterface $configResolver;
     private FragmentHandler $fragmentHandler;

--- a/bundle/View/Provider/Configured.php
+++ b/bundle/View/Provider/Configured.php
@@ -148,11 +148,10 @@ class Configured implements ViewProvider
 
         $redirectConfig = RedirectConfiguration::fromConfigurationArray($viewConfig['redirect']);
 
-        $dto->addParameters(
-            [
-                'path' => $this->redirectResolver->resolveTarget($redirectConfig, $view),
-                'permanent' => $redirectConfig->isPermanent(),
-            ],
-        );
+        $dto->addParameters([
+            'path' => $this->redirectResolver->resolveTarget($redirectConfig, $view),
+            'permanent' => $redirectConfig->isPermanent(),
+            'keepRequestMethod' => $redirectConfig->keepRequestMethod(),
+        ]);
     }
 }

--- a/bundle/View/Redirect/RedirectConfiguration.php
+++ b/bundle/View/Redirect/RedirectConfiguration.php
@@ -9,24 +9,32 @@ final class RedirectConfiguration
     private string $target;
     private array $targetParameters;
     private bool $permanent;
+    private bool $keepRequestMethod;
     private bool $absolute;
 
-    public function __construct(string $target, array $targetParameters, bool $permanent, bool $absolute)
-    {
+    public function __construct(
+        string $target,
+        array $targetParameters,
+        bool $permanent,
+        bool $keepRequestMethod,
+        bool $absolute
+    ) {
         $this->target = $target;
         $this->targetParameters = $targetParameters;
         $this->permanent = $permanent;
+        $this->keepRequestMethod = $keepRequestMethod;
         $this->absolute = $absolute;
     }
 
     public static function fromConfigurationArray(array $config): self
     {
-        $target = $config['target'];
-        $targetParameters = $config['target_parameters'];
-        $permanent = $config['permanent'];
-        $absolute = $config['absolute'];
-
-        return new self($target, $targetParameters, $permanent, $absolute);
+        return new self(
+            $config['target'],
+            $config['target_parameters'],
+            $config['permanent'],
+            $config['keep_request_method'],
+            $config['absolute'],
+        );
     }
 
     public function getTarget(): string
@@ -42,6 +50,11 @@ final class RedirectConfiguration
     public function isPermanent(): bool
     {
         return $this->permanent;
+    }
+
+    public function keepRequestMethod(): bool
+    {
+        return $this->keepRequestMethod;
     }
 
     public function isAbsolute(): bool

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -235,7 +235,7 @@ With Site API, it's also possible to configure redirects directly from the view 
 You can set up temporary or permanent redirect to either ``Content``, ``Location``, ``Tag``, Symfony route or any full url.
 
 For the target configuration you can use expression language, meaning it is easily possible to redirect, for example,
-to the parent of the current location, or to the named object.
+to the parent of the current location, or to a named object.
 
 Example configuration:
 
@@ -251,6 +251,7 @@ Example configuration:
                             target_parameters:
                                 foo: bar
                             permanent: false
+                            keep_request_method: true
                         match:
                             Identifier\ContentType: container
                     article:
@@ -260,6 +261,7 @@ Example configuration:
                                 foo: bar
                                 siteaccess: cro
                             permanent: true
+                            keep_request_method: '%kernel.debug%'
                             absolute: true
                         match:
                             Identifier\ContentType: article
@@ -267,6 +269,7 @@ Example configuration:
                         redirect:
                             target: '@=location.firstChild("article")'
                             permanent: true
+                            keep_request_method: false
                         match:
                             Identifier\ContentType: category
                     news:
@@ -297,6 +300,29 @@ There also shortcuts available for simplified configuration:
                             Identifier\ContentType: container
                     category:
                         permanent_redirect: '@=content.getFieldRelation("internal_redirect")'
+                        match:
+                            Identifier\ContentType: container
+
+Which is functionally identical to:
+
+.. code-block:: yaml
+
+    ibexa:
+        system:
+            frontend_group:
+                ng_content_view:
+                    container:
+                        redirect:
+                            target: '@=namedObject.getTag("running")'
+                            permanent: false
+                            keep_request_method: true
+                        match:
+                            Identifier\ContentType: container
+                    category:
+                        redirect:
+                            target: '@=content.getFieldRelation("internal_redirect")'
+                            permanent: true
+                            keep_request_method: true
                         match:
                             Identifier\ContentType: container
 


### PR DESCRIPTION
To go with:
- https://github.com/netgen/media-site/pull/78

This adds `keep_request_method` to the redirect configuration, which will produce `301` and `302` redirects when false, and `307` and `308` redirects when true.

The option is true by default, as `307` and `308` redirects will probably become well supported defaults in the future.