### PR TITLE
NGSTACK-379: expand redirect configuration

### DIFF
--- a/bundle/DependencyInjection/Compiler/BasedTaggedRegistryPass.php
+++ b/bundle/DependencyInjection/Compiler/BasedTaggedRegistryPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use function array_keys;
+
+abstract class BasedTaggedRegistryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has(static::RegistryId)) {
+            return;
+        }
+
+        $registryDefinition = $container->getDefinition(static::RegistryId);
+        $registrees = $container->findTaggedServiceIds(static::RegistreeTag);
+
+        foreach (array_keys($registrees) as $registreeId) {
+            $registryDefinition->addMethodCall(
+                static::RegisterMethod,
+                [new Reference($registreeId)],
+            );
+        }
+    }
+}

--- a/bundle/DependencyInjection/Compiler/NamedObjectExpressionFunctionProviderPass.php
+++ b/bundle/DependencyInjection/Compiler/NamedObjectExpressionFunctionProviderPass.php
@@ -4,30 +4,9 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
-use function array_keys;
-
-final class NamedObjectExpressionFunctionProviderPass implements CompilerPassInterface
+final class NamedObjectExpressionFunctionProviderPass extends BasedTaggedRegistryPass
 {
-    private const QueryTypeExpressionLanguageId = 'netgen.ibexa_site_api.named_object.expression_language';
-    private const QueryTypeExpressionFunctionProviderTag = 'netgen.ibexa_site_api.named_object.expression_function_provider';
-
-    public function process(ContainerBuilder $container): void
-    {
-        if (!$container->has(self::QueryTypeExpressionLanguageId)) {
-            return;
-        }
-
-        $expressionLanguageDefinition = $container->getDefinition(self::QueryTypeExpressionLanguageId);
-        $functionProviders = $container->findTaggedServiceIds(self::QueryTypeExpressionFunctionProviderTag);
-
-        foreach (array_keys($functionProviders) as $functionProviderId) {
-            $expressionLanguageDefinition->addMethodCall(
-                'registerProvider',
-                [new Reference($functionProviderId)],
-            );
-        }
-    }
+    protected const RegistryId = 'netgen.ibexa_site_api.named_object.expression_language';
+    protected const RegistreeTag = 'netgen.ibexa_site_api.named_object.expression_function_provider';
+    protected const RegisterMethod = 'registerProvider';
 }

--- a/bundle/DependencyInjection/Compiler/PreviewControllerOverridePass.php
+++ b/bundle/DependencyInjection/Compiler/PreviewControllerOverridePass.php
@@ -33,7 +33,6 @@ class PreviewControllerOverridePass implements CompilerPassInterface
                 [new Reference('netgen.ibexa_site_api.core.site')],
             );
 
-        // todo check
         // Redefine the alias as it seems to be mangled in some cases
         // See https://github.com/netgen/ezplatform-site-api/pull/168
         $container->setAlias(

--- a/bundle/DependencyInjection/Compiler/QueryTypeExpressionFunctionProviderPass.php
+++ b/bundle/DependencyInjection/Compiler/QueryTypeExpressionFunctionProviderPass.php
@@ -4,30 +4,9 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
-use function array_keys;
-
-final class QueryTypeExpressionFunctionProviderPass implements CompilerPassInterface
+final class QueryTypeExpressionFunctionProviderPass extends BasedTaggedRegistryPass
 {
-    private const QueryTypeExpressionLanguageId = 'netgen.ibexa_site_api.query_type.expression_language';
-    private const QueryTypeExpressionFunctionProviderTag = 'netgen.ibexa_site_api.query_type.expression_function_provider';
-
-    public function process(ContainerBuilder $container): void
-    {
-        if (!$container->has(self::QueryTypeExpressionLanguageId)) {
-            return;
-        }
-
-        $expressionLanguageDefinition = $container->getDefinition(self::QueryTypeExpressionLanguageId);
-        $functionProviders = $container->findTaggedServiceIds(self::QueryTypeExpressionFunctionProviderTag);
-
-        foreach (array_keys($functionProviders) as $functionProviderId) {
-            $expressionLanguageDefinition->addMethodCall(
-                'registerProvider',
-                [new Reference($functionProviderId)],
-            );
-        }
-    }
+    protected const RegistryId = 'netgen.ibexa_site_api.query_type.expression_language';
+    protected const RegistreeTag = 'netgen.ibexa_site_api.query_type.expression_function_provider';
+    protected const RegisterMethod = 'registerProvider';
 }

--- a/bundle/DependencyInjection/Compiler/RedirectExpressionFunctionProviderPass.php
+++ b/bundle/DependencyInjection/Compiler/RedirectExpressionFunctionProviderPass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler;
+
+final class RedirectExpressionFunctionProviderPass extends BasedTaggedRegistryPass
+{
+    protected const RegistryId = 'netgen.ibexa_site_api.redirect.expression_language';
+    protected const RegistreeTag = 'netgen.ibexa_site_api.redirect.expression_function_provider';
+    protected const RegisterMethod = 'registerProvider';
+}

--- a/bundle/DependencyInjection/Compiler/RelationResolverRegistrationPass.php
+++ b/bundle/DependencyInjection/Compiler/RelationResolverRegistrationPass.php
@@ -22,7 +22,7 @@ final class RelationResolverRegistrationPass implements CompilerPassInterface
      *
      * @var string
      */
-    private $resolverRegistryId = 'netgen.ibexa_site_api.plugins.field_type.relation_resolver.registry';
+    private string $resolverRegistryId = 'netgen.ibexa_site_api.plugins.field_type.relation_resolver.registry';
 
     /**
      * Service tag used for field type relation resolvers.
@@ -31,7 +31,7 @@ final class RelationResolverRegistrationPass implements CompilerPassInterface
      *
      * @var string
      */
-    private $resolverTag = 'netgen.ibexa_site_api.plugins.field_type.relation_resolver';
+    private string $resolverTag = 'netgen.ibexa_site_api.plugins.field_type.relation_resolver';
 
     public function process(ContainerBuilder $container): void
     {

--- a/bundle/DependencyInjection/Compiler/ViewBuilderRegistrationPass.php
+++ b/bundle/DependencyInjection/Compiler/ViewBuilderRegistrationPass.php
@@ -12,7 +12,6 @@ class ViewBuilderRegistrationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        // todo check
         if (!$container->has(ViewBuilderRegistry::class)) {
             return;
         }

--- a/bundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/bundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -105,7 +105,7 @@ class ContentView extends AbstractParser
                                         ->defaultFalse()
                                     ->end()
                                     ->scalarNode('keep_request_method')
-                                        ->defaultTrue()
+                                        ->defaultFalse()
                                     ->end()
                                     ->scalarNode('absolute')
                                         ->defaultFalse()

--- a/bundle/Exception/InvalidRedirectConfiguration.php
+++ b/bundle/Exception/InvalidRedirectConfiguration.php
@@ -8,10 +8,10 @@ use Exception;
 
 final class InvalidRedirectConfiguration extends Exception
 {
-    public function __construct(string $target)
+    public function __construct(string $target, Exception $previous = null)
     {
-        $message = "Not possible to resolve redirect from given target: '{$target}'";
+        $message = "Could not resolve redirect from the given target: '$target'";
 
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/bundle/NamedObject/ParameterProcessor.php
+++ b/bundle/NamedObject/ParameterProcessor.php
@@ -6,11 +6,8 @@ namespace Netgen\Bundle\IbexaSiteApiBundle\NamedObject;
 
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Netgen\Bundle\IbexaSiteApiBundle\Traits\LanguageExpressionEvaluatorTrait;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use function is_string;
-use function mb_strlen;
-use function mb_strpos;
-use function mb_substr;
 
 /**
  * ParameterProcessor processes query configuration parameter values using ExpressionLanguage.
@@ -19,10 +16,7 @@ use function mb_substr;
  */
 final class ParameterProcessor
 {
-    /**
-     * @var string
-     */
-    private const ExpressionMarker = '@=';
+    use LanguageExpressionEvaluatorTrait;
 
     private ExpressionLanguage $expressionLanguage;
     private ConfigResolverInterface $configResolver;
@@ -49,26 +43,13 @@ final class ParameterProcessor
      */
     public function process($value)
     {
-        if (!$this->isExpression($value)) {
-            return $value;
-        }
-
-        return $this->expressionLanguage->evaluate(
-            $this->extractExpression($value),
+        return $this->evaluate(
+            $value,
+            $this->expressionLanguage,
             [
                 'configResolver' => $this->configResolver,
                 'currentUserId' => $this->permissionResolver->getCurrentUserReference()->getUserId(),
-            ],
+            ]
         );
-    }
-
-    private function isExpression($value): bool
-    {
-        return is_string($value) && mb_strpos($value, self::ExpressionMarker) === 0;
-    }
-
-    private function extractExpression(string $value): string
-    {
-        return mb_substr($value, mb_strlen(self::ExpressionMarker));
     }
 }

--- a/bundle/NetgenIbexaSiteApiBundle.php
+++ b/bundle/NetgenIbexaSiteApiBundle.php
@@ -9,6 +9,7 @@ use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\InvalidRedirec
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\NamedObjectExpressionFunctionProviderPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\PreviewControllerOverridePass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\QueryTypeExpressionFunctionProviderPass;
+use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\RedirectExpressionFunctionProviderPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\ViewBuilderRegistrationPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Configuration\Parser\ContentView;
@@ -27,6 +28,7 @@ class NetgenIbexaSiteApiBundle extends Bundle
         $container->addCompilerPass(new NamedObjectExpressionFunctionProviderPass());
         $container->addCompilerPass(new PreviewControllerOverridePass());
         $container->addCompilerPass(new QueryTypeExpressionFunctionProviderPass());
+        $container->addCompilerPass(new RedirectExpressionFunctionProviderPass());
         $container->addCompilerPass(new RelationResolverRegistrationPass());
         $container->addCompilerPass(new ViewBuilderRegistrationPass());
 

--- a/bundle/QueryType/ParameterProcessor.php
+++ b/bundle/QueryType/ParameterProcessor.php
@@ -6,13 +6,10 @@ namespace Netgen\Bundle\IbexaSiteApiBundle\QueryType;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Netgen\Bundle\IbexaSiteApiBundle\NamedObject\Provider;
+use Netgen\Bundle\IbexaSiteApiBundle\Traits\LanguageExpressionEvaluatorTrait;
 use Netgen\Bundle\IbexaSiteApiBundle\View\ContentView;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\RequestStack;
-use function is_string;
-use function mb_strlen;
-use function mb_strpos;
-use function mb_substr;
 
 /**
  * ParameterProcessor processes query configuration parameter values using ExpressionLanguage.
@@ -21,10 +18,7 @@ use function mb_substr;
  */
 final class ParameterProcessor
 {
-    /**
-     * @var string
-     */
-    private const ExpressionMarker = '@=';
+    use LanguageExpressionEvaluatorTrait;
 
     private ExpressionLanguage $expressionLanguage;
     private RequestStack $requestStack;
@@ -54,12 +48,9 @@ final class ParameterProcessor
      */
     public function process($value, ContentView $view)
     {
-        if (!$this->isExpression($value)) {
-            return $value;
-        }
-
-        return $this->expressionLanguage->evaluate(
-            $this->extractExpression($value),
+        return $this->evaluate(
+            $value,
+            $this->expressionLanguage,
             [
                 'view' => $view,
                 'location' => $view->getSiteLocation(),
@@ -67,17 +58,7 @@ final class ParameterProcessor
                 'request' => $this->requestStack->getCurrentRequest(),
                 'configResolver' => $this->configResolver,
                 'namedObject' => $this->namedObjectProvider,
-            ],
+            ]
         );
-    }
-
-    private function isExpression($value): bool
-    {
-        return is_string($value) && mb_strpos($value, self::ExpressionMarker) === 0;
-    }
-
-    private function extractExpression(string $value): string
-    {
-        return mb_substr($value, mb_strlen(self::ExpressionMarker));
     }
 }

--- a/bundle/Resources/config/services/redirect.yaml
+++ b/bundle/Resources/config/services/redirect.yaml
@@ -1,0 +1,27 @@
+services:
+    # Expression language function providers tagged with
+    # 'netgen.ibexa_site_api.redirect.expression_function_provider'
+    # are registered to this service
+    netgen.ibexa_site_api.redirect.expression_language:
+        class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
+
+    netgen.ibexa_site_api.redirect.expression_function_provider:
+        class: Netgen\Bundle\IbexaSiteApiBundle\View\Redirect\ExpressionFunctionProvider
+        arguments:
+            - '@service_container'
+        tags:
+            - { name: netgen.ibexa_site_api.redirect.expression_function_provider }
+
+    netgen.ibexa_site_api.redirect.resolver:
+        class: Netgen\Bundle\IbexaSiteApiBundle\View\Redirect\Resolver
+        arguments:
+            - '@router'
+        public: false
+
+    netgen.ibexa_site_api.redirect.parameter_processor:
+        class: Netgen\Bundle\IbexaSiteApiBundle\View\Redirect\ParameterProcessor
+        arguments:
+            - '@netgen.ibexa_site_api.redirect.expression_language'
+            - '@ibexa.config.resolver'
+            - '@netgen.ibexa_site_api.named_object.provider'
+        public: false

--- a/bundle/Resources/config/services/view.yaml
+++ b/bundle/Resources/config/services/view.yaml
@@ -25,8 +25,9 @@ services:
         arguments:
             - '@netgen.ibexa_site_api.ngcontent_view.matcher_factory'
             - '@netgen.ibexa_site_api.query_type.query_definition_mapper'
-            - '@netgen.ibexa_site_api.redirect_resolver'
+            - '@netgen.ibexa_site_api.redirect.resolver'
             - '@netgen.ibexa_site_api.view_provider.content_view_fallback_resolver'
+            - '@netgen.ibexa_site_api.redirect.parameter_processor'
         tags:
             - { name: ibexa.view.provider, type: 'Netgen\Bundle\IbexaSiteApiBundle\View\ContentView', priority: 110 }
         public: false
@@ -47,23 +48,9 @@ services:
             - '@ibexa.content_view.matcher_factory'
             - '@netgen.ibexa_site_api.view_provider.content_view_fallback_resolver'
 
-    netgen.ibexa_site_api.redirect_resolver:
-        class: Netgen\Bundle\IbexaSiteApiBundle\View\Redirect\Resolver
-        arguments:
-            - '@netgen.ibexa_site_api.redirect.parameter_processor'
-            - '@router'
-        public: false
-
-    netgen.ibexa_site_api.redirect.parameter_processor:
-        class: Netgen\Bundle\IbexaSiteApiBundle\View\Redirect\ParameterProcessor
-        arguments:
-            - '@netgen.ibexa_site_api.named_object.provider'
-        public: false
-
     netgen.ibexa_site_api.ngcontent_view.matcher_factory:
         class: Netgen\Bundle\IbexaSiteApiBundle\View\Matcher\MatcherFactory
         arguments:
-            # todo check optional
             - '@?Ibexa\Bundle\Core\Matcher\ViewMatcherRegistry'
             - '@ibexa.api.repository'
             - 'Ibexa\Core\MVC\Symfony\Matcher\ContentBased'
@@ -84,7 +71,6 @@ services:
     netgen.ibexa_site_api.ngcontent_view.default_matcher_factory:
         class: Netgen\Bundle\IbexaSiteApiBundle\View\Matcher\MatcherFactory
         arguments:
-            # todo check optional
             - '@?Ibexa\Bundle\Core\Matcher\ViewMatcherRegistry'
             - '@ibexa.api.repository'
             - 'Ibexa\Core\MVC\Symfony\Matcher\ContentBased'

--- a/bundle/Traits/LanguageExpressionEvaluatorTrait.php
+++ b/bundle/Traits/LanguageExpressionEvaluatorTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaSiteApiBundle\Traits;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use function mb_strpos;
+use function mb_substr;
+
+/**
+ * Common implementation for processing language expressions.
+ */
+trait LanguageExpressionEvaluatorTrait
+{
+    private static string $expressionMarker = '@=';
+
+    /**
+     * Return given $value processed with ExpressionLanguage if needed.
+     *
+     * Parameter $view is used to provide values for evaluation.
+     *
+     * @param mixed $value
+     */
+    protected function evaluate(
+        $value,
+        ExpressionLanguage $expressionLanguage,
+        array $values
+    ) {
+        if (is_array($value)) {
+            return $this->evaluateParameters($value, $expressionLanguage, $values);
+        }
+
+        if (!$this->isExpression($value)) {
+            return $value;
+        }
+
+        return $expressionLanguage->evaluate(
+            $this->extractExpression($value),
+            $values,
+        );
+    }
+
+    /**
+     * Recursively process given $parameters using ParameterProcessor.
+     *
+     * @see \Netgen\Bundle\IbexaSiteApiBundle\QueryType\ParameterProcessor
+     */
+    private function evaluateParameters(
+        array $parameters,
+        ExpressionLanguage $expressionLanguage,
+        array $values
+    ): array {
+        $processedParameters = [];
+
+        foreach ($parameters as $name => $subParameters) {
+            $processedParameters[$name] = $this->evaluate(
+                $subParameters,
+                $expressionLanguage,
+                $values
+            );
+        }
+
+        return $processedParameters;
+    }
+
+    private function isExpression($value): bool
+    {
+        return is_string($value) && mb_strpos($value, self::$expressionMarker) === 0;
+    }
+
+    private function extractExpression(string $value): string
+    {
+        return mb_substr($value, mb_strlen(self::$expressionMarker));
+    }
+}

--- a/bundle/View/Redirect/ExpressionFunctionProvider.php
+++ b/bundle/View/Redirect/ExpressionFunctionProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaSiteApiBundle\View\Redirect;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+class ExpressionFunctionProvider implements ExpressionFunctionProviderInterface
+{
+    private ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction(
+                'namedContent',
+                static function (): void {},
+                static function (array $arguments, string $name) {
+                    /** @var \Netgen\Bundle\IbexaSiteApiBundle\NamedObject\Provider $namedObjectProvider */
+                    $namedObjectProvider = $arguments['namedObject'];
+
+                    return $namedObjectProvider->getContent($name);
+                },
+            ),
+            new ExpressionFunction(
+                'namedLocation',
+                static function (): void {},
+                static function (array $arguments, string $name) {
+                    /** @var \Netgen\Bundle\IbexaSiteApiBundle\NamedObject\Provider $namedObjectProvider */
+                    $namedObjectProvider = $arguments['namedObject'];
+
+                    return $namedObjectProvider->getLocation($name);
+                },
+            ),
+            new ExpressionFunction(
+                'namedTag',
+                static function (): void {},
+                static function (array $arguments, string $name) {
+                    /** @var \Netgen\Bundle\IbexaSiteApiBundle\NamedObject\Provider $namedObjectProvider */
+                    $namedObjectProvider = $arguments['namedObject'];
+
+                    return $namedObjectProvider->getTag($name);
+                },
+            ),
+            new ExpressionFunction(
+                'config',
+                static function (): void {},
+                static function (array $arguments, string $name, ?string $namespace = null, ?string $scope = null) {
+                    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface $configResolver */
+                    $configResolver = $arguments['configResolver'];
+
+                    return $configResolver->getParameter($name, $namespace, $scope);
+                },
+            ),
+            new ExpressionFunction(
+                'parameter',
+                static function (): void {},
+                function (array $arguments, string $name) {
+                    return $this->container->getParameter($name);
+                },
+            ),
+        ];
+    }
+}

--- a/bundle/View/Redirect/RedirectConfiguration.php
+++ b/bundle/View/Redirect/RedirectConfiguration.php
@@ -6,14 +6,15 @@ namespace Netgen\Bundle\IbexaSiteApiBundle\View\Redirect;
 
 final class RedirectConfiguration
 {
-    private string $target;
+    /** @var object|string */
+    private $target;
     private array $targetParameters;
     private bool $permanent;
     private bool $keepRequestMethod;
     private bool $absolute;
 
     public function __construct(
-        string $target,
+        $target,
         array $targetParameters,
         bool $permanent,
         bool $keepRequestMethod,
@@ -37,7 +38,7 @@ final class RedirectConfiguration
         );
     }
 
-    public function getTarget(): string
+    public function getTarget()
     {
         return $this->target;
     }

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -242,7 +242,7 @@ particular Content view. Available parameters and their default values are:
 
 - ``target_parameters: []`` - Symfony route parameters used when the target is a Symfony route
 - ``permanent: false`` - whether the redirect will be permanent or temporary (``301`` or ``302``)
-- ``keep_request_method: true`` - whether to keep the request method
+- ``keep_request_method: false`` - whether to keep the request method
 
     If enabled, this will result in ``308`` for a permanent and ``307`` for a temporary redirect.
 

--- a/docs/reference/query_types.rst
+++ b/docs/reference/query_types.rst
@@ -410,6 +410,23 @@ Shortcut functions are available for accessing each type of named object directl
 
     Provides access to named Tag.
 
+
+With the shortcut functions, the example from the above can be written as:
+
+.. code-block:: yaml
+
+    ibexa:
+        system:
+            frontend_group:
+                ng_site_api:
+                    named_queries:
+                        top_categories:
+                            query_type: 'SiteAPI:Location/Children'
+                            parameters:
+                                location: '@=namedLocation("homepage")'
+                                content_type: 'category'
+                                sort: 'name desc'
+
 Miscellaneous
 ~~~~~~~~~~~~~
 

--- a/tests/bundle/DependencyInjection/Compiler/NamedObjectExpressionFunctionProviderPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/NamedObjectExpressionFunctionProviderPassTest.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Netgen\Bundle\IbexaSiteApiBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\QueryTypeExpressionFunctionProviderPass;
+use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\NamedObjectExpressionFunctionProviderPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @internal
  */
-final class QueryTypeExpressionFunctionProviderPassTest extends AbstractCompilerPassTestCase
+final class NamedObjectExpressionFunctionProviderPassTest extends AbstractCompilerPassTestCase
 {
-    protected const ExpressionLanguageId = 'netgen.ibexa_site_api.query_type.expression_language';
-    protected const ExpressionFunctionProviderTag = 'netgen.ibexa_site_api.query_type.expression_function_provider';
+    protected const ExpressionLanguageId = 'netgen.ibexa_site_api.named_object.expression_language';
+    protected const ExpressionFunctionProviderTag = 'netgen.ibexa_site_api.named_object.expression_function_provider';
 
     protected function setUp(): void
     {
@@ -45,6 +45,6 @@ final class QueryTypeExpressionFunctionProviderPassTest extends AbstractCompiler
 
     protected function registerCompilerPass(ContainerBuilder $container): void
     {
-        $container->addCompilerPass(new QueryTypeExpressionFunctionProviderPass());
+        $container->addCompilerPass(new NamedObjectExpressionFunctionProviderPass());
     }
 }

--- a/tests/bundle/DependencyInjection/Compiler/RedirectExpressionFunctionProviderPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/RedirectExpressionFunctionProviderPassTest.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Netgen\Bundle\IbexaSiteApiBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\QueryTypeExpressionFunctionProviderPass;
+use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\RedirectExpressionFunctionProviderPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @internal
  */
-final class QueryTypeExpressionFunctionProviderPassTest extends AbstractCompilerPassTestCase
+final class RedirectExpressionFunctionProviderPassTest extends AbstractCompilerPassTestCase
 {
-    protected const ExpressionLanguageId = 'netgen.ibexa_site_api.query_type.expression_language';
-    protected const ExpressionFunctionProviderTag = 'netgen.ibexa_site_api.query_type.expression_function_provider';
+    protected const ExpressionLanguageId = 'netgen.ibexa_site_api.redirect.expression_language';
+    protected const ExpressionFunctionProviderTag = 'netgen.ibexa_site_api.redirect.expression_function_provider';
 
     protected function setUp(): void
     {
@@ -45,6 +45,6 @@ final class QueryTypeExpressionFunctionProviderPassTest extends AbstractCompiler
 
     protected function registerCompilerPass(ContainerBuilder $container): void
     {
-        $container->addCompilerPass(new QueryTypeExpressionFunctionProviderPass());
+        $container->addCompilerPass(new RedirectExpressionFunctionProviderPass());
     }
 }


### PR DESCRIPTION
This expands use of redirect configuration language expressions, making possible to use them in all configuration parameters, including target parameters. For example:

```yaml
match_all:
    redirect:
        target: '@=namedLocation("homepage")'
        permanent: "@=!parameter('kernel.debug')"
        keep_request_method: '%kernel.debug%'
    match: ~
```

Please see updated docs for more details.