### PR TITLE
NGSTACK-719: Return an empty variation if image does not exist

### DIFF
--- a/bundle/Templating/Twig/Extension/ImageRuntime.php
+++ b/bundle/Templating/Twig/Extension/ImageRuntime.php
@@ -29,7 +29,7 @@ class ImageRuntime
     /**
      * Returns the image variation object for $field/$versionInfo.
      */
-    public function getImageVariation(Field $field, string $variationName): ?Variation
+    public function getImageVariation(Field $field, string $variationName): Variation
     {
         /** @var \Ibexa\Core\FieldType\Image\Value $value */
         $value = $field->value;
@@ -52,6 +52,6 @@ class ImageRuntime
             );
         }
 
-        return null;
+        return new Variation();
     }
 }


### PR DESCRIPTION
This prevents exceptions with `Impossible to access an attribute ("uri") on a null variable.` in Twig

(cherry picked from commit b8f03a36747c599e6c0e6e525d1daab12ec9b2ec)