### PR TITLE
NGSTACK-714: override URL alias generator

### DIFF
--- a/bundle/DependencyInjection/Compiler/UrlAliasGeneratorOverridePass.php
+++ b/bundle/DependencyInjection/Compiler/UrlAliasGeneratorOverridePass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler;
+
+use Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator as IbexaUrlAliasGenerator;
+use Netgen\Bundle\IbexaSiteApiBundle\Routing\UrlAliasGenerator as SiteApiUrlAliasGenerator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class UrlAliasGeneratorOverridePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(IbexaUrlAliasGenerator::class)) {
+            return;
+        }
+
+        $container
+            ->findDefinition(IbexaUrlAliasGenerator::class)
+            ->setClass(SiteApiUrlAliasGenerator::class);
+    }
+}

--- a/bundle/NetgenIbexaSiteApiBundle.php
+++ b/bundle/NetgenIbexaSiteApiBundle.php
@@ -10,6 +10,7 @@ use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\PreviewControl
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\QueryTypeExpressionFunctionProviderPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\RedirectExpressionFunctionProviderPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
+use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\UrlAliasGeneratorOverridePass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\UrlAliasRouterOverridePass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\ViewBuilderRegistrationPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Configuration\Parser\ContentView;
@@ -23,6 +24,7 @@ class NetgenIbexaSiteApiBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new UrlAliasGeneratorOverridePass());
         $container->addCompilerPass(new UrlAliasRouterOverridePass());
         $container->addCompilerPass(new InvalidRedirectConfigurationListenerPass());
         $container->addCompilerPass(new NamedObjectExpressionFunctionProviderPass());

--- a/bundle/Routing/UrlAliasGenerator.php
+++ b/bundle/Routing/UrlAliasGenerator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaSiteApiBundle\Routing;
+
+use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator as BaseUrlAliasGenerator;
+use Symfony\Component\Routing\RouterInterface;
+
+class UrlAliasGenerator extends BaseUrlAliasGenerator
+{
+    private Repository $repository;
+
+    public function __construct(
+        Repository $repository,
+        RouterInterface $defaultRouter,
+        ConfigResolverInterface $configResolver,
+        array $unsafeCharMap = []
+    ) {
+        parent::__construct($repository, $defaultRouter, $configResolver, $unsafeCharMap);
+
+        $this->repository = $repository;
+    }
+
+    public function loadLocation($locationId): Location
+    {
+        return $this->repository->sudo(
+            static function (Repository $repository) use ($locationId) {
+                return $repository->getLocationService()->loadLocation($locationId, []);
+            }
+        );
+    }
+}


### PR DESCRIPTION
This overrides Ibexa core URL alias generator to avoid siteaccess-aware contraption getting in the way of cross-siteaccess router.