### PR TITLE
NGSTACK-735: check if Site API is enabled before using overridden routing

### DIFF
--- a/bundle/Resources/config/services/routing.yaml
+++ b/bundle/Resources/config/services/routing.yaml
@@ -6,6 +6,7 @@ services:
             - '@Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator'
             - '@netgen.ibexa_site_api.siteaccess.resolver'
             - '@router.request_context'
+            - '@ibexa.config.resolver'
         tags:
             - { name: router, priority: 300 }
         lazy: true

--- a/bundle/Routing/GeneratorRouter.php
+++ b/bundle/Routing/GeneratorRouter.php
@@ -140,12 +140,12 @@ class GeneratorRouter implements ChainedRouterInterface, RequestMatcherInterface
 
         $url = $this->generator->generate($location, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 
-        if ($referenceType === UrlGeneratorInterface::RELATIVE_PATH) {
-            $host = $this->requestContext->getHost();
-            $hostLength = mb_strlen($host);
+        if ($referenceType === UrlGeneratorInterface::RELATIVE_PATH || $referenceType === UrlGeneratorInterface::ABSOLUTE_PATH) {
+            $prefix = $this->requestContext->getScheme() . '://' . $this->requestContext->getHost();
+            $prefixLength = mb_strlen($prefix);
 
-            if (mb_strpos($url, $host) === 0) {
-                return mb_substr($url, $hostLength);
+            if (mb_strpos($url, $prefix) === 0) {
+                return mb_substr($url, $prefixLength);
             }
         }
 

--- a/bundle/Routing/GeneratorRouter.php
+++ b/bundle/Routing/GeneratorRouter.php
@@ -8,6 +8,7 @@ use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo as APIContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use Ibexa\Core\MVC\Symfony\Routing\UrlAliasRouter as CoreUrlAliasRouter;
 use LogicException;
@@ -40,17 +41,20 @@ class GeneratorRouter implements ChainedRouterInterface, RequestMatcherInterface
     private UrlAliasGenerator $generator;
     private Resolver $siteaccessResolver;
     private RequestContext $requestContext;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(
         Repository $repository,
         UrlAliasGenerator $generator,
         Resolver $siteaccessResolver,
-        RequestContext $requestContext
+        RequestContext $requestContext,
+        ConfigResolverInterface $configResolver
     ) {
         $this->repository = $repository;
         $this->generator = $generator;
         $this->siteaccessResolver = $siteaccessResolver;
         $this->requestContext = $requestContext;
+        $this->configResolver = $configResolver;
     }
 
     /**
@@ -61,6 +65,12 @@ class GeneratorRouter implements ChainedRouterInterface, RequestMatcherInterface
         array $parameters = [],
         int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH
     ): string {
+        $isSiteApiPrimaryContentView = $this->configResolver->getParameter('ng_site_api.site_api_is_primary_content_view');
+
+        if (!$isSiteApiPrimaryContentView) {
+            throw new RouteNotFoundException('Pass to the next router');
+        }
+
         $location = $this->resolveLocation($name, $parameters);
 
         unset(

--- a/bundle/Routing/UrlAliasGenerator.php
+++ b/bundle/Routing/UrlAliasGenerator.php
@@ -13,6 +13,7 @@ use Symfony\Component\Routing\RouterInterface;
 class UrlAliasGenerator extends BaseUrlAliasGenerator
 {
     private Repository $repository;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(
         Repository $repository,
@@ -23,10 +24,17 @@ class UrlAliasGenerator extends BaseUrlAliasGenerator
         parent::__construct($repository, $defaultRouter, $configResolver, $unsafeCharMap);
 
         $this->repository = $repository;
+        $this->configResolver = $configResolver;
     }
 
     public function loadLocation($locationId): Location
     {
+        $isSiteApiPrimaryContentView = $this->configResolver->getParameter('ng_site_api.site_api_is_primary_content_view');
+
+        if (!$isSiteApiPrimaryContentView) {
+            return parent::loadLocation($locationId);
+        }
+
         return $this->repository->sudo(
             static fn (Repository $repository) => $repository->getLocationService()->loadLocation($locationId, []),
         );


### PR DESCRIPTION
Two fixes are here:
- stripping scheme and host for URL types (https://github.com/netgen/ibexa-site-api/commit/96573809677cb84c0b9a5658f5514a7975282965)
- using Site API routing overrides only whey Site API is enabled (https://github.com/netgen/ibexa-site-api/commit/5a4235e63bdf12361de1902420da06ea1f50c575)

Note that since it's possible to switch siteaccess dynamically, router overrides need to be always active and switching needs to be dynamic as well.