### PR TITLE
Cast locationId and contentId to integer

### DIFF
--- a/bundle/View/Builder/ContentViewBuilder.php
+++ b/bundle/View/Builder/ContentViewBuilder.php
@@ -59,7 +59,7 @@ class ContentViewBuilder implements ViewBuilder
         }
 
         if (isset($parameters['locationId'])) {
-            $location = $this->loadLocation($parameters['locationId']);
+            $location = $this->loadLocation((int) $parameters['locationId']);
         } elseif (isset($parameters['location'])) {
             $location = $parameters['location'];
             if ($location instanceof APILocation) {
@@ -76,7 +76,7 @@ class ContentViewBuilder implements ViewBuilder
             }
         } else {
             if (isset($parameters['contentId'])) {
-                $contentId = $parameters['contentId'];
+                $contentId = (int) $parameters['contentId'];
             } elseif (isset($location)) {
                 $contentId = $location->contentInfo->id;
             } else {


### PR DESCRIPTION
It turns out they can end up as strings when supplied to route config via container parameters