### PR TITLE
Remove debug info

### DIFF
--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -137,22 +137,6 @@ final class Content extends APIContent
         };
     }
 
-    public function __debugInfo(): array
-    {
-        return [
-            'id' => $this->id,
-            'mainLocationId' => $this->mainLocationId,
-            'name' => $this->name,
-            'languageCode' => $this->languageCode,
-            'isVisible' => $this->getContentInfo()->isVisible,
-            'contentInfo' => $this->getContentInfo(),
-            'fields' => $this->fields,
-            'mainLocation' => '[An instance of Netgen\IbexaSiteApi\API\Values\Location]',
-            'innerContent' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\Content]',
-            'innerVersionInfo' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo]',
-        ];
-    }
-
     public function hasField(string $identifier): bool
     {
         return $this->fields->hasField($identifier);

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -80,34 +80,6 @@ final class ContentInfo extends APIContentInfo
         return parent::__isset($property);
     }
 
-    public function __debugInfo(): array
-    {
-        return [
-            'id' => $this->innerContentInfo->id,
-            'contentTypeId' => $this->innerContentInfo->contentTypeId,
-            'sectionId' => $this->innerContentInfo->sectionId,
-            'currentVersionNo' => $this->innerContentInfo->currentVersionNo,
-            'published' => $this->innerContentInfo->published,
-            'isHidden' => $this->innerContentInfo->isHidden,
-            'isVisible' => !$this->innerContentInfo->isHidden,
-            'ownerId' => $this->innerContentInfo->ownerId,
-            'modificationDate' => $this->innerContentInfo->modificationDate,
-            'publishedDate' => $this->innerContentInfo->publishedDate,
-            'alwaysAvailable' => $this->innerContentInfo->alwaysAvailable,
-            'remoteId' => $this->innerContentInfo->remoteId,
-            'mainLanguageCode' => $this->innerContentInfo->mainLanguageCode,
-            'mainLocationId' => $this->innerContentInfo->mainLocationId,
-            'name' => $this->name,
-            'languageCode' => $this->languageCode,
-            'contentTypeIdentifier' => $this->contentTypeIdentifier,
-            'contentTypeName' => $this->contentTypeName,
-            'contentTypeDescription' => $this->contentTypeDescription,
-            'innerContentInfo' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo]',
-            'innerContentType' => '[An instance of Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType]',
-            'mainLocation' => '[An instance of Netgen\IbexaSiteApi\API\Values\Location]',
-        ];
-    }
-
     private function getMainLocation(): ?APILocation
     {
         if ($this->internalMainLocation === null && $this->mainLocationId !== null) {

--- a/lib/Core/Site/Values/Field.php
+++ b/lib/Core/Site/Values/Field.php
@@ -35,25 +35,6 @@ final class Field extends APIField
         parent::__construct($properties);
     }
 
-    public function __debugInfo(): array
-    {
-        return [
-            'id' => $this->id,
-            'fieldDefIdentifier' => $this->fieldDefIdentifier,
-            'value' => $this->value,
-            'languageCode' => $this->languageCode,
-            'fieldTypeIdentifier' => $this->fieldTypeIdentifier,
-            'name' => $this->name,
-            'description' => $this->description,
-            'content' => '[An instance of Netgen\IbexaSiteApi\API\Values\Content]',
-            'contentId' => $this->content->id,
-            'isEmpty' => $this->isEmpty,
-            'isSurrogate' => $this->isSurrogate,
-            'innerField' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\Field]',
-            'innerFieldDefinition' => $this->innerFieldDefinition,
-        ];
-    }
-
     public function isEmpty(): bool
     {
         return $this->isEmpty;

--- a/lib/Core/Site/Values/Fields.php
+++ b/lib/Core/Site/Values/Fields.php
@@ -49,13 +49,6 @@ final class Fields extends APIFields
     ) {
     }
 
-    public function __debugInfo(): array
-    {
-        $this->initialize();
-
-        return $this->fieldsByIdentifier;
-    }
-
     public function getIterator(): Traversable
     {
         $this->initialize();

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -120,31 +120,6 @@ final class Location extends APILocation
         return parent::__isset($property);
     }
 
-    public function __debugInfo(): array
-    {
-        return [
-            'id' => $this->innerLocation->id,
-            'status' => $this->innerLocation->status,
-            'priority' => $this->innerLocation->priority,
-            'hidden' => $this->innerLocation->hidden,
-            'invisible' => $this->innerLocation->invisible,
-            'explicitlyHidden' => $this->innerLocation->explicitlyHidden,
-            'isVisible' => !$this->innerLocation->hidden && !$this->innerLocation->invisible,
-            'remoteId' => $this->innerLocation->remoteId,
-            'parentLocationId' => $this->innerLocation->parentLocationId,
-            'pathString' => $this->innerLocation->pathString,
-            'path' => $this->innerLocation->path,
-            'depth' => $this->innerLocation->depth,
-            'sortField' => $this->innerLocation->sortField,
-            'sortOrder' => $this->innerLocation->sortOrder,
-            'contentId' => $this->innerLocation->contentId,
-            'innerLocation' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\Location]',
-            'contentInfo' => $this->getContentInfo(),
-            'parent' => '[An instance of Netgen\IbexaSiteApi\API\Values\Location]',
-            'content' => '[An instance of Netgen\IbexaSiteApi\API\Values\Content]',
-        ];
-    }
-
     public function getChildren(int $limit = 25): array
     {
         return $this->filterChildren([], $limit)->getIterator()->getArrayCopy();

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -144,22 +144,6 @@ abstract class BaseTest extends APIBaseTest
         } catch (PropertyNotFoundException) {
             // Do nothing
         }
-
-        self::assertSame(
-            [
-                'id' => $content->id,
-                'mainLocationId' => $content->mainLocationId,
-                'name' => $content->name,
-                'languageCode' => $content->languageCode,
-                'isVisible' => $content->isVisible,
-                'contentInfo' => $content->contentInfo,
-                'fields' => $content->fields,
-                'mainLocation' => '[An instance of Netgen\IbexaSiteApi\API\Values\Location]',
-                'innerContent' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\Content]',
-                'innerVersionInfo' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo]',
-            ],
-            $content->__debugInfo(),
-        );
     }
 
     protected function assertContentInfo(APIContentInfo $contentInfo, array $data): void
@@ -203,34 +187,6 @@ abstract class BaseTest extends APIBaseTest
         } catch (PropertyNotFoundException) {
             // Do nothing
         }
-
-        self::assertSame(
-            [
-                'id' => $contentInfo->id,
-                'contentTypeId' => $contentInfo->contentTypeId,
-                'sectionId' => $contentInfo->sectionId,
-                'currentVersionNo' => $contentInfo->currentVersionNo,
-                'published' => $contentInfo->published,
-                'isHidden' => $contentInfo->isHidden,
-                'isVisible' => !$contentInfo->isHidden,
-                'ownerId' => $contentInfo->ownerId,
-                'modificationDate' => $contentInfo->modificationDate,
-                'publishedDate' => $contentInfo->publishedDate,
-                'alwaysAvailable' => $contentInfo->alwaysAvailable,
-                'remoteId' => $contentInfo->remoteId,
-                'mainLanguageCode' => $contentInfo->mainLanguageCode,
-                'mainLocationId' => $contentInfo->mainLocationId,
-                'name' => $contentInfo->name,
-                'languageCode' => $contentInfo->languageCode,
-                'contentTypeIdentifier' => $contentInfo->contentTypeIdentifier,
-                'contentTypeName' => $contentInfo->contentTypeName,
-                'contentTypeDescription' => $contentInfo->contentTypeDescription,
-                'innerContentInfo' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo]',
-                'innerContentType' => '[An instance of Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType]',
-                'mainLocation' => '[An instance of Netgen\IbexaSiteApi\API\Values\Location]',
-            ],
-            $contentInfo->__debugInfo(),
-        );
     }
 
     protected function assertFields(Content $content, array $data): void
@@ -300,25 +256,6 @@ abstract class BaseTest extends APIBaseTest
         } catch (PropertyNotFoundException) {
             // Do nothing
         }
-
-        self::assertSame(
-            [
-                'id' => $field->id,
-                'fieldDefIdentifier' => $field->fieldDefIdentifier,
-                'value' => $field->value,
-                'languageCode' => $field->languageCode,
-                'fieldTypeIdentifier' => $field->fieldTypeIdentifier,
-                'name' => $field->name,
-                'description' => $field->description,
-                'content' => '[An instance of Netgen\IbexaSiteApi\API\Values\Content]',
-                'contentId' => $field->content->id,
-                'isEmpty' => $field->isEmpty(),
-                'isSurrogate' => $field->isSurrogate(),
-                'innerField' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\Field]',
-                'innerFieldDefinition' => $field->innerFieldDefinition,
-            ],
-            $field->__debugInfo(),
-        );
     }
 
     protected function assertLocation(Location $location, array $data): void
@@ -373,30 +310,5 @@ abstract class BaseTest extends APIBaseTest
         } catch (PropertyNotFoundException) {
             // Do nothing
         }
-
-        self::assertSame(
-            [
-                'id' => $location->id,
-                'status' => $location->status,
-                'priority' => $location->priority,
-                'hidden' => $location->hidden,
-                'invisible' => $location->invisible,
-                'explicitlyHidden' => $location->explicitlyHidden,
-                'isVisible' => $location->isVisible,
-                'remoteId' => $location->remoteId,
-                'parentLocationId' => $location->parentLocationId,
-                'pathString' => $location->pathString,
-                'path' => $location->path,
-                'depth' => $location->depth,
-                'sortField' => $location->sortField,
-                'sortOrder' => $location->sortOrder,
-                'contentId' => $location->contentId,
-                'innerLocation' => '[An instance of Ibexa\Contracts\Core\Repository\Values\Content\Location]',
-                'contentInfo' => $location->contentInfo,
-                'parent' => '[An instance of Netgen\IbexaSiteApi\API\Values\Location]',
-                'content' => '[An instance of Netgen\IbexaSiteApi\API\Values\Content]',
-            ],
-            $location->__debugInfo(),
-        );
     }
 }

--- a/tests/lib/Unit/Core/Site/Values/FieldsTest.php
+++ b/tests/lib/Unit/Core/Site/Values/FieldsTest.php
@@ -301,16 +301,6 @@ final class FieldsTest extends TestCase
         self::assertTrue($field->isEmpty());
     }
 
-    public function testDebugInfo(): void
-    {
-        $fields = $this->getFieldsUnderTest(true);
-
-        self::assertSame(
-            (array) $fields->getIterator(),
-            $fields->__debugInfo(),
-        );
-    }
-
     protected function getFieldsUnderTest(bool $failOnMissingField): Fields
     {
         return new Fields(


### PR DESCRIPTION
XDebug does not play nicely with it, and besides we don't need it anymore since Symfony's var dumper can handle circular references.