### PR TITLE
Always pass resolved siteaccess to avoid missing root Location ID in CLI context

### DIFF
--- a/bundle/Routing/GeneratorRouter.php
+++ b/bundle/Routing/GeneratorRouter.php
@@ -157,10 +157,6 @@ class GeneratorRouter implements ChainedRouterInterface, RequestMatcherInterface
             $siteaccess = $this->currentSiteaccess->name;
         }
 
-        if ($siteaccess === $this->currentSiteaccess->name) {
-            return $this->generator->generate($location, $parameters, $referenceType);
-        }
-
         $parameters['siteaccess'] = $siteaccess;
 
         $url = $this->generator->generate(


### PR DESCRIPTION
Ibexa Core depends on `KernelEvents::REQUEST` event to dispatch `MVCEvents::SITEACCESS` event, which executes `RoutingListener` to see the root Location ID on the URL Generator. Since `KernelEvents::REQUEST` event is not dispatched in CLI context, root Location ID is not set on the URL Generator and path prefix is not stripped from the generated URL.

This always passes the siteaccess resolved by the cross-siteaccess router, even when it's the same as the current siteaccess. It should not make a change in the request context, but in CLI context the path prefix will be correctly stripped as configured for the default siteaccess.