### PR TITLE
Revert "Always pass resolved siteaccess to avoid missing root Location ID in CLI context"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,7 @@ jobs:
             - run: composer validate --strict
             - run: composer update --prefer-dist
             - run: vendor/bin/phpunit -c ${{ matrix.phpunit }} --colors=always --coverage-clover=coverage.xml
-            - run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.coverage }}
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v3
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/bundle/Routing/GeneratorRouter.php
+++ b/bundle/Routing/GeneratorRouter.php
@@ -157,6 +157,10 @@ class GeneratorRouter implements ChainedRouterInterface, RequestMatcherInterface
             $siteaccess = $this->currentSiteaccess->name;
         }
 
+        if ($siteaccess === $this->currentSiteaccess->name) {
+            return $this->generator->generate($location, $parameters, $referenceType);
+        }
+
         $parameters['siteaccess'] = $siteaccess;
 
         $url = $this->generator->generate(


### PR DESCRIPTION
This reverts commit 2f6edc9abb0342e7cefd71c14f58c8703485162f from #27.

Making this change was a mistake, since Ibexa can't omit default siteaccess from URL if it's explicitly passed to the URL generator. Overriding the vendor implementation to enable for that would be too big an effort for a rather small gain.

Also see https://github.com/ibexa/core/pull/352