### PR TITLE
NGSTACK-900: implement debug info 

### DIFF
--- a/bundle/DependencyInjection/Compiler/VarDumperPass.php
+++ b/bundle/DependencyInjection/Compiler/VarDumperPass.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler;
+
+use Netgen\IbexaSiteApi\API\Values\DebugInfo;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\VarDumper\Caster\Caster;
+
+class VarDumperPass implements CompilerPassInterface
+{
+    private const ClonerId = 'var_dumper.cloner';
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(self::ClonerId)) {
+            return;
+        }
+
+        $clonerDefinition = $container->findDefinition(self::ClonerId);
+
+        $clonerDefinition->addMethodCall(
+            'addCasters',
+            [
+                '$casters' => [
+                    DebugInfo::class => [self::class, 'cast'],
+                ],
+            ],
+        );
+    }
+
+    public static function cast(DebugInfo $object, array $array): array
+    {
+        $debugInfo = $object->getDebugInfo();
+        $debugData = [];
+
+        foreach ($debugInfo as $key => $value) {
+            if (!isset($key[0]) || $key[0] !== "\0") {
+                if (array_key_exists(Caster::PREFIX_DYNAMIC . $key, $array)) {
+                    continue;
+                }
+
+                $key = Caster::PREFIX_VIRTUAL . $key;
+            }
+
+            unset($array[$key]);
+
+            $debugData[$key] = $value;
+        }
+
+        return array_merge($debugData, $array);
+    }
+}

--- a/bundle/NetgenIbexaSiteApiBundle.php
+++ b/bundle/NetgenIbexaSiteApiBundle.php
@@ -12,6 +12,7 @@ use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\RedirectExpres
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\RelationResolverRegistrationPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\UrlAliasGeneratorOverridePass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\UrlAliasRouterOverridePass;
+use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\VarDumperPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Compiler\ViewBuilderRegistrationPass;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Configuration\Parser\ContentView;
 use Netgen\Bundle\IbexaSiteApiBundle\DependencyInjection\Configuration\Parser\SiteApi;
@@ -32,6 +33,7 @@ class NetgenIbexaSiteApiBundle extends Bundle
         $container->addCompilerPass(new QueryTypeExpressionFunctionProviderPass());
         $container->addCompilerPass(new RedirectExpressionFunctionProviderPass());
         $container->addCompilerPass(new RelationResolverRegistrationPass());
+        $container->addCompilerPass(new VarDumperPass());
         $container->addCompilerPass(new ViewBuilderRegistrationPass());
 
         /** @var \Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension $coreExtension */

--- a/lib/API/Values/Content.php
+++ b/lib/API/Values/Content.php
@@ -34,7 +34,7 @@ use Pagerfanta\Pagerfanta;
  * @property-read \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $innerVersionInfo
  * @property-read \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
  */
-abstract class Content extends ValueObject
+abstract class Content extends ValueObject implements DebugInfo
 {
     /**
      * Returns if Content has the field with the given field definition $identifier.

--- a/lib/API/Values/ContentInfo.php
+++ b/lib/API/Values/ContentInfo.php
@@ -36,4 +36,4 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  * @property-read \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType $innerContentType
  * @property-read ?\Netgen\IbexaSiteApi\API\Values\Location $mainLocation
  */
-abstract class ContentInfo extends ValueObject {}
+abstract class ContentInfo extends ValueObject implements DebugInfo {}

--- a/lib/API/Values/DebugInfo.php
+++ b/lib/API/Values/DebugInfo.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\IbexaSiteApi\API\Values;
+
+/**
+ * Provides debug information for view developers.
+ */
+interface DebugInfo
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getDebugInfo(): array;
+}

--- a/lib/API/Values/Field.php
+++ b/lib/API/Values/Field.php
@@ -24,7 +24,7 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  * @property-read \Ibexa\Contracts\Core\Repository\Values\Content\Field $innerField
  * @property-read \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $innerFieldDefinition
  */
-abstract class Field extends ValueObject
+abstract class Field extends ValueObject implements DebugInfo
 {
     abstract public function isEmpty(): bool;
 

--- a/lib/API/Values/Fields.php
+++ b/lib/API/Values/Fields.php
@@ -13,7 +13,7 @@ use IteratorAggregate;
  *
  * @see \Netgen\IbexaSiteApi\API\Values\Field
  */
-abstract class Fields implements IteratorAggregate, ArrayAccess, Countable
+abstract class Fields implements IteratorAggregate, ArrayAccess, Countable, DebugInfo
 {
     /**
      * Return whether the collection contains a field with the given $identifier.

--- a/lib/API/Values/Location.php
+++ b/lib/API/Values/Location.php
@@ -36,7 +36,7 @@ use Pagerfanta\Pagerfanta;
  * @property-read ?\Netgen\IbexaSiteApi\API\Values\Location $parent
  * @property-read \Ibexa\Contracts\Core\Repository\Values\Content\Location $innerLocation
  */
-abstract class Location extends ValueObject
+abstract class Location extends ValueObject implements DebugInfo
 {
     /**
      * Return an array of children Locations, limited by optional $limit.

--- a/lib/Core/Site/Values/Content.php
+++ b/lib/Core/Site/Values/Content.php
@@ -498,4 +498,23 @@ final class Content extends APIContent
 
         return $this->url;
     }
+
+    public function getDebugInfo(): array
+    {
+        return [
+            'id' => $this->id,
+            'mainLocationId' => $this->mainLocationId,
+            'name' => $this->name,
+            'languageCode' => $this->languageCode,
+            'isVisible' => $this->getContentInfo()->isVisible,
+            'url' => $this->getUrl(),
+            'path' => $this->getPath(),
+            'owner' => $this->getOwner(),
+            'modifier' => $this->getModifier(),
+            'mainLocation' => $this->getMainLocation(),
+            'locations' => $this->getLocations(),
+            'contentInfo' => $this->getContentInfo(),
+            'fields' => $this->fields,
+        ];
+    }
 }

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -100,7 +100,7 @@ final class ContentInfo extends APIContentInfo
             'name' => $this->name,
             'published' => $this->innerContentInfo->published,
             'currentVersionNo' => $this->innerContentInfo->currentVersionNo,
-            'publicationDate' => $this->innerContentInfo->publishedDate,
+            'publishedDate' => $this->innerContentInfo->publishedDate,
             'modificationDate' => $this->innerContentInfo->modificationDate,
             'languageCode' => $this->languageCode,
             'mainLanguageCode' => $this->innerContentInfo->mainLanguageCode,
@@ -109,7 +109,7 @@ final class ContentInfo extends APIContentInfo
             'isHidden' => $this->innerContentInfo->isHidden,
             'sectionId' => $this->innerContentInfo->sectionId,
             'ownerId' => $this->innerContentInfo->ownerId,
-            'contentType' => $this->innerContentType,
+            'innerContentType' => $this->innerContentType,
             'mainLocation' => $this->getMainLocation(),
         ];
     }

--- a/lib/Core/Site/Values/ContentInfo.php
+++ b/lib/Core/Site/Values/ContentInfo.php
@@ -90,4 +90,27 @@ final class ContentInfo extends APIContentInfo
 
         return $this->internalMainLocation;
     }
+
+    public function getDebugInfo(): array
+    {
+        return [
+            'id' => $this->innerContentInfo->id,
+            'mainLocationId' => $this->innerContentInfo->mainLocationId,
+            'remoteId' => $this->innerContentInfo->remoteId,
+            'name' => $this->name,
+            'published' => $this->innerContentInfo->published,
+            'currentVersionNo' => $this->innerContentInfo->currentVersionNo,
+            'publicationDate' => $this->innerContentInfo->publishedDate,
+            'modificationDate' => $this->innerContentInfo->modificationDate,
+            'languageCode' => $this->languageCode,
+            'mainLanguageCode' => $this->innerContentInfo->mainLanguageCode,
+            'alwaysAvailable' => $this->innerContentInfo->alwaysAvailable,
+            'isVisible' => !$this->innerContentInfo->isHidden,
+            'isHidden' => $this->innerContentInfo->isHidden,
+            'sectionId' => $this->innerContentInfo->sectionId,
+            'ownerId' => $this->innerContentInfo->ownerId,
+            'contentType' => $this->innerContentType,
+            'mainLocation' => $this->getMainLocation(),
+        ];
+    }
 }

--- a/lib/Core/Site/Values/Field.php
+++ b/lib/Core/Site/Values/Field.php
@@ -44,4 +44,22 @@ final class Field extends APIField
     {
         return $this->isSurrogate;
     }
+
+    public function getDebugInfo(): array
+    {
+        return [
+            'id' => $this->id,
+            'contentId' => $this->content->id,
+            'fieldDefIdentifier' => $this->fieldDefIdentifier,
+            'fieldTypeIdentifier' => $this->fieldTypeIdentifier,
+            'languageCode' => $this->languageCode,
+            'name' => $this->name,
+            'description' => $this->description,
+            'isEmpty' => $this->isEmpty,
+            'isSurrogate' => $this->isSurrogate,
+            'content' => $this->content,
+            'fieldDefinition' => $this->innerFieldDefinition,
+            'value' => $this->value,
+        ];
+    }
 }

--- a/lib/Core/Site/Values/Field.php
+++ b/lib/Core/Site/Values/Field.php
@@ -58,7 +58,7 @@ final class Field extends APIField
             'isEmpty' => $this->isEmpty,
             'isSurrogate' => $this->isSurrogate,
             'content' => $this->content,
-            'fieldDefinition' => $this->innerFieldDefinition,
+            'innerFieldDefinition' => $this->innerFieldDefinition,
             'value' => $this->value,
         ];
     }

--- a/lib/Core/Site/Values/Fields.php
+++ b/lib/Core/Site/Values/Fields.php
@@ -245,4 +245,11 @@ final class Fields extends APIFields
             'isSurrogate' => true,
         ]);
     }
+
+    public function getDebugInfo(): array
+    {
+        $this->initialize();
+
+        return $this->fieldsByIdentifier;
+    }
 }

--- a/lib/Core/Site/Values/Location.php
+++ b/lib/Core/Site/Values/Location.php
@@ -312,4 +312,29 @@ final class Location extends APILocation
 
         return $this->url;
     }
+
+    public function getDebugInfo(): array
+    {
+        return [
+            'id' => $this->innerLocation->id,
+            'contentId' => $this->innerLocation->contentId,
+            'remoteId' => $this->innerLocation->remoteId,
+            'status' => $this->innerLocation->status,
+            'priority' => $this->innerLocation->priority,
+            'hidden' => $this->innerLocation->hidden,
+            'invisible' => $this->innerLocation->invisible,
+            'explicitlyHidden' => $this->innerLocation->explicitlyHidden,
+            'isVisible' => !$this->innerLocation->hidden && !$this->innerLocation->invisible,
+            'pathString' => $this->innerLocation->pathString,
+            'pathArray' => $this->innerLocation->path,
+            'depth' => $this->innerLocation->depth,
+            'sortField' => $this->innerLocation->sortField,
+            'sortOrder' => $this->innerLocation->sortOrder,
+            'path' => $this->getPath(),
+            'url' => $this->getUrl(),
+            'content' => $this->getContent(),
+            'contentInfo' => $this->getContentInfo(),
+            'parent' => $this->getParent(),
+        ];
+    }
 }


### PR DESCRIPTION
This implements debug info intended for view developers and customized Symfony's var dumper for our domain objects.