### PR TITLE
NGSTACK-904: use Core Content View Builder for rendering Ibexa views

### DIFF
--- a/bundle/Resources/config/services/view.yaml
+++ b/bundle/Resources/config/services/view.yaml
@@ -88,6 +88,7 @@ services:
         class: Netgen\Bundle\IbexaSiteApiBundle\View\ContentRenderer
         arguments:
             - '@netgen.ibexa_site_api.view_builder.content'
+            - '@Ibexa\Core\MVC\Symfony\View\Builder\ContentViewBuilder'
             - '@netgen.ibexa_site_api.view_renderer'
             - '@?logger'
         tags:

--- a/bundle/View/ContentRenderer.php
+++ b/bundle/View/ContentRenderer.php
@@ -8,6 +8,7 @@ use Exception;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
+use Ibexa\Core\MVC\Symfony\View\Builder\ContentViewBuilder as CoreContentViewBuilder;
 use LogicException;
 use Netgen\Bundle\IbexaSiteApiBundle\View\Builder\ContentViewBuilder;
 use Netgen\IbexaSiteApi\API\Values\Content;
@@ -27,6 +28,7 @@ final class ContentRenderer
 {
     public function __construct(
         private readonly ContentViewBuilder $viewBuilder,
+        private readonly CoreContentViewBuilder $coreViewBuilder,
         private readonly ViewRenderer $viewRenderer,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {}
@@ -110,7 +112,7 @@ final class ContentRenderer
             $baseParameters['location'] = $location;
         }
 
-        $view = $this->viewBuilder->buildView($baseParameters + $parameters);
+        $view = $this->coreViewBuilder->buildView($baseParameters + $parameters);
 
         return $this->viewRenderer->render($view, $parameters, $layout);
     }
@@ -127,7 +129,7 @@ final class ContentRenderer
         ];
 
         try {
-            $view = $this->viewBuilder->buildView($baseParameters + $parameters);
+            $view = $this->coreViewBuilder->buildView($baseParameters + $parameters);
         } catch (Exception $exception) {
             $this->logger->error(
                 sprintf(

--- a/tests/lib/Integration/BaseTest.php
+++ b/tests/lib/Integration/BaseTest.php
@@ -155,7 +155,6 @@ abstract class BaseTest extends APIBaseTest
         self::assertSame($locationId, $contentInfo->mainLocationId);
         self::assertSame($name, $contentInfo->name);
         self::assertSame($data['contentTypeIdentifier'], $contentInfo->contentTypeIdentifier);
-        self::assertSame($data['contentTypeId'], $contentInfo->contentTypeId);
         self::assertSame($data['sectionId'], $contentInfo->sectionId);
         self::assertSame($data['currentVersionNo'], $contentInfo->currentVersionNo);
         self::assertSame($data['published'], $contentInfo->published);


### PR DESCRIPTION
Rendering Ibexa views should use Ibexa ContentViewBuilder instead of Site API one. Without this, rendering Ibexa view when Site API is a primary Content view and fallback without subrequest is enabled results in an infinite loop, since the fallback template is always being resolved.

Fixes #32 